### PR TITLE
Add esbuild wasm version as bundle argument

### DIFF
--- a/lib/cjs/index.d.ts
+++ b/lib/cjs/index.d.ts
@@ -1,4 +1,9 @@
-declare const bundle: (rawCode: string) => Promise<{
+interface BundleArgs {
+    rawCode: string;
+    typescript?: boolean;
+    versionTag?: string;
+}
+declare const bundle: ({ rawCode, typescript, versionTag }: BundleArgs) => Promise<{
     code: string;
     err: any;
 }>;

--- a/lib/cjs/index.js
+++ b/lib/cjs/index.js
@@ -86,7 +86,7 @@ var bundle = function (_a) {
                             write: false,
                             plugins: plugins,
                             define: {
-                                'process.env.NODE_ENV': '"production"',
+                                [['process','env','NODE_ENV'].join(".")]: '"production"',
                                 global: 'window'
                             },
                         })];

--- a/lib/cjs/index.js
+++ b/lib/cjs/index.js
@@ -59,45 +59,52 @@ var esbuild = __importStar(require("esbuild-wasm"));
 var unpkg_path_plugin_1 = require("./plugins/unpkg-path-plugin");
 var fetch_plugin_1 = require("./plugins/fetch-plugin");
 var service;
-var bundle = function (rawCode) { return __awaiter(void 0, void 0, void 0, function () {
-    var result, err_1;
-    return __generator(this, function (_a) {
-        switch (_a.label) {
-            case 0:
-                if (!!service) return [3 /*break*/, 2];
-                return [4 /*yield*/, esbuild.startService({
-                        worker: true,
-                        wasmURL: 'https://unpkg.com/esbuild-wasm@0.8.36/esbuild.wasm'
-                    })];
-            case 1:
-                service = _a.sent();
-                _a.label = 2;
-            case 2:
-                _a.trys.push([2, 4, , 5]);
-                return [4 /*yield*/, service.build({
-                        entryPoints: ['index.js'],
-                        bundle: true,
-                        write: false,
-                        plugins: [unpkg_path_plugin_1.unpkgPathPlugin(), fetch_plugin_1.fetchPlugin(rawCode)],
-                        define: {
-                            'process.env.NODE_ENV': '"production"',
-                            global: 'window'
-                        },
-                    })];
-            case 3:
-                result = _a.sent();
-                return [2 /*return*/, {
-                        code: result.outputFiles[0].text,
-                        err: '',
-                    }];
-            case 4:
-                err_1 = _a.sent();
-                return [2 /*return*/, {
-                        code: '',
-                        err: err_1.message,
-                    }];
-            case 5: return [2 /*return*/];
-        }
+var bundle = function (_a) {
+    var rawCode = _a.rawCode, _b = _a.typescript, typescript = _b === void 0 ? false : _b, _c = _a.versionTag, versionTag = _c === void 0 ? '0.8.36' : _c;
+    return __awaiter(void 0, void 0, void 0, function () {
+        var entryPoint, plugins, result, err_1;
+        return __generator(this, function (_d) {
+            switch (_d.label) {
+                case 0:
+                    if (!!service) return [3 /*break*/, 2];
+                    return [4 /*yield*/, esbuild.startService({
+                            worker: true,
+                            wasmURL: "https://unpkg.com/esbuild-wasm@" + versionTag + "/esbuild.wasm",
+                        })];
+                case 1:
+                    service = _d.sent();
+                    _d.label = 2;
+                case 2:
+                    entryPoint = (typescript) ? 'index.ts' : 'index.js';
+                    plugins = typescript ? [unpkg_path_plugin_1.tsUnpkgPathPlugin(), fetch_plugin_1.tsxFetchPlugin(rawCode)] : [unpkg_path_plugin_1.unpkgPathPlugin(), fetch_plugin_1.fetchPlugin(rawCode)];
+                    _d.label = 3;
+                case 3:
+                    _d.trys.push([3, 5, , 6]);
+                    return [4 /*yield*/, service.build({
+                            entryPoints: [entryPoint],
+                            bundle: true,
+                            write: false,
+                            plugins: plugins,
+                            define: {
+                                'process.env.NODE_ENV': '"production"',
+                                global: 'window'
+                            },
+                        })];
+                case 4:
+                    result = _d.sent();
+                    return [2 /*return*/, {
+                            code: result.outputFiles[0].text,
+                            err: '',
+                        }];
+                case 5:
+                    err_1 = _d.sent();
+                    return [2 /*return*/, {
+                            code: '',
+                            err: err_1.message,
+                        }];
+                case 6: return [2 /*return*/];
+            }
+        });
     });
-}); };
+};
 exports.default = bundle;

--- a/lib/cjs/plugins/fetch-plugin.d.ts
+++ b/lib/cjs/plugins/fetch-plugin.d.ts
@@ -3,3 +3,7 @@ export declare const fetchPlugin: (inputCode: string) => {
     name: string;
     setup(build: esbuild.PluginBuild): void;
 };
+export declare const tsxFetchPlugin: (inputCode: string) => {
+    name: string;
+    setup(build: esbuild.PluginBuild): void;
+};

--- a/lib/cjs/plugins/fetch-plugin.js
+++ b/lib/cjs/plugins/fetch-plugin.js
@@ -39,11 +39,11 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.fetchPlugin = void 0;
+exports.tsxFetchPlugin = exports.fetchPlugin = void 0;
 var localforage_1 = __importDefault(require("localforage"));
 var axios_1 = __importDefault(require("axios"));
 var fileCache = localforage_1.default.createInstance({
-    name: 'filecache'
+    name: 'filecache',
 });
 var fetchPlugin = function (inputCode) {
     return {
@@ -79,10 +79,7 @@ var fetchPlugin = function (inputCode) {
                         case 0: return [4 /*yield*/, axios_1.default.get(args.path)];
                         case 1:
                             _a = _b.sent(), data = _a.data, request = _a.request;
-                            escaped = data
-                                .replace(/\n/g, '')
-                                .replace(/"/g, '\\"')
-                                .replace(/'/g, "\\'");
+                            escaped = data.replace(/\n/g, '').replace(/"/g, '\\"').replace(/'/g, "\\'");
                             contents = "\n            const style = document.createElement('style');\n            style.innerText = '" + escaped + "';\n            document.head.appendChild(style);\n          ";
                             result = {
                                 loader: 'jsx',
@@ -116,7 +113,80 @@ var fetchPlugin = function (inputCode) {
                     }
                 });
             }); });
-        }
+        },
     };
 };
 exports.fetchPlugin = fetchPlugin;
+var tsxFetchPlugin = function (inputCode) {
+    return {
+        name: 'fetch-plugin',
+        setup: function (build) {
+            var _this = this;
+            // load index.ts file
+            build.onLoad({ filter: /(^index\.ts$)/ }, function () {
+                return {
+                    loader: 'tsx',
+                    contents: inputCode,
+                };
+            });
+            // check the file cache
+            build.onLoad({ filter: /.*/ }, function (args) { return __awaiter(_this, void 0, void 0, function () {
+                var cachedResult;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0: return [4 /*yield*/, fileCache.getItem(args.path)];
+                        case 1:
+                            cachedResult = _a.sent();
+                            if (cachedResult) {
+                                return [2 /*return*/, cachedResult];
+                            }
+                            return [2 /*return*/];
+                    }
+                });
+            }); });
+            // load css files
+            build.onLoad({ filter: /.css$/ }, function (args) { return __awaiter(_this, void 0, void 0, function () {
+                var _a, data, request, escaped, contents, result;
+                return __generator(this, function (_b) {
+                    switch (_b.label) {
+                        case 0: return [4 /*yield*/, axios_1.default.get(args.path)];
+                        case 1:
+                            _a = _b.sent(), data = _a.data, request = _a.request;
+                            escaped = data.replace(/\n/g, '').replace(/"/g, '\\"').replace(/'/g, "\\'");
+                            contents = "\n            const style = document.createElement('style');\n            style.innerText = '" + escaped + "';\n            document.head.appendChild(style);\n          ";
+                            result = {
+                                loader: 'ts',
+                                contents: contents,
+                                resolveDir: new URL('./', request.responseURL).pathname,
+                            };
+                            return [4 /*yield*/, fileCache.setItem(args.path, result)];
+                        case 2:
+                            _b.sent();
+                            return [2 /*return*/, result];
+                    }
+                });
+            }); });
+            // load javascript / jsx files
+            build.onLoad({ filter: /.*/ }, function (args) { return __awaiter(_this, void 0, void 0, function () {
+                var _a, data, request, result;
+                return __generator(this, function (_b) {
+                    switch (_b.label) {
+                        case 0: return [4 /*yield*/, axios_1.default.get(args.path)];
+                        case 1:
+                            _a = _b.sent(), data = _a.data, request = _a.request;
+                            result = {
+                                loader: 'tsx',
+                                contents: data,
+                                resolveDir: new URL('./', request.responseURL).pathname,
+                            };
+                            return [4 /*yield*/, fileCache.setItem(args.path, result)];
+                        case 2:
+                            _b.sent();
+                            return [2 /*return*/, result];
+                    }
+                });
+            }); });
+        },
+    };
+};
+exports.tsxFetchPlugin = tsxFetchPlugin;

--- a/lib/cjs/plugins/unpkg-path-plugin.d.ts
+++ b/lib/cjs/plugins/unpkg-path-plugin.d.ts
@@ -3,3 +3,7 @@ export declare const unpkgPathPlugin: () => {
     name: string;
     setup(build: esbuild.PluginBuild): void;
 };
+export declare const tsUnpkgPathPlugin: () => {
+    name: string;
+    setup(build: esbuild.PluginBuild): void;
+};

--- a/lib/cjs/plugins/unpkg-path-plugin.js
+++ b/lib/cjs/plugins/unpkg-path-plugin.js
@@ -36,7 +36,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.unpkgPathPlugin = void 0;
+exports.tsUnpkgPathPlugin = exports.unpkgPathPlugin = void 0;
 var unpkgPathPlugin = function () {
     return {
         name: 'unpkg-path-plugin',
@@ -66,3 +66,32 @@ var unpkgPathPlugin = function () {
     };
 };
 exports.unpkgPathPlugin = unpkgPathPlugin;
+var tsUnpkgPathPlugin = function () {
+    return {
+        name: 'unpkg-path-plugin',
+        setup: function (build) {
+            var _this = this;
+            // handle root entry file of 'index.ts'
+            build.onResolve({ filter: /(^index\.ts$)/ }, function () {
+                return { path: 'index.ts', namespace: 'a' };
+            });
+            // handle relative paths in a module
+            build.onResolve({ filter: /^\.+\// }, function (args) {
+                return {
+                    namespace: 'a',
+                    path: new URL(args.path, 'https://unpkg.com' + args.resolveDir + '/').href,
+                };
+            });
+            // handle main file of a module
+            build.onResolve({ filter: /.*/ }, function (args) { return __awaiter(_this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
+                    return [2 /*return*/, {
+                            namespace: 'a',
+                            path: "https://unpkg.com/" + args.path,
+                        }];
+                });
+            }); });
+        },
+    };
+};
+exports.tsUnpkgPathPlugin = tsUnpkgPathPlugin;

--- a/lib/esm/index.d.ts
+++ b/lib/esm/index.d.ts
@@ -1,4 +1,9 @@
-declare const bundle: (rawCode: string) => Promise<{
+interface BundleArgs {
+    rawCode: string;
+    typescript?: boolean;
+    versionTag?: string;
+}
+declare const bundle: ({ rawCode, typescript, versionTag }: BundleArgs) => Promise<{
     code: string;
     err: any;
 }>;

--- a/lib/esm/index.js
+++ b/lib/esm/index.js
@@ -35,48 +35,55 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 import * as esbuild from 'esbuild-wasm';
-import { unpkgPathPlugin } from './plugins/unpkg-path-plugin';
-import { fetchPlugin } from './plugins/fetch-plugin';
+import { unpkgPathPlugin, tsUnpkgPathPlugin } from './plugins/unpkg-path-plugin';
+import { fetchPlugin, tsxFetchPlugin } from './plugins/fetch-plugin';
 var service;
-var bundle = function (rawCode) { return __awaiter(void 0, void 0, void 0, function () {
-    var result, err_1;
-    return __generator(this, function (_a) {
-        switch (_a.label) {
-            case 0:
-                if (!!service) return [3 /*break*/, 2];
-                return [4 /*yield*/, esbuild.startService({
-                        worker: true,
-                        wasmURL: 'https://unpkg.com/esbuild-wasm@0.8.36/esbuild.wasm'
-                    })];
-            case 1:
-                service = _a.sent();
-                _a.label = 2;
-            case 2:
-                _a.trys.push([2, 4, , 5]);
-                return [4 /*yield*/, service.build({
-                        entryPoints: ['index.js'],
-                        bundle: true,
-                        write: false,
-                        plugins: [unpkgPathPlugin(), fetchPlugin(rawCode)],
-                        define: {
-                            'process.env.NODE_ENV': '"production"',
-                            global: 'window'
-                        },
-                    })];
-            case 3:
-                result = _a.sent();
-                return [2 /*return*/, {
-                        code: result.outputFiles[0].text,
-                        err: '',
-                    }];
-            case 4:
-                err_1 = _a.sent();
-                return [2 /*return*/, {
-                        code: '',
-                        err: err_1.message,
-                    }];
-            case 5: return [2 /*return*/];
-        }
+var bundle = function (_a) {
+    var rawCode = _a.rawCode, _b = _a.typescript, typescript = _b === void 0 ? false : _b, _c = _a.versionTag, versionTag = _c === void 0 ? '0.8.36' : _c;
+    return __awaiter(void 0, void 0, void 0, function () {
+        var entryPoint, plugins, result, err_1;
+        return __generator(this, function (_d) {
+            switch (_d.label) {
+                case 0:
+                    if (!!service) return [3 /*break*/, 2];
+                    return [4 /*yield*/, esbuild.startService({
+                            worker: true,
+                            wasmURL: "https://unpkg.com/esbuild-wasm@" + versionTag + "/esbuild.wasm",
+                        })];
+                case 1:
+                    service = _d.sent();
+                    _d.label = 2;
+                case 2:
+                    entryPoint = (typescript) ? 'index.ts' : 'index.js';
+                    plugins = typescript ? [tsUnpkgPathPlugin(), tsxFetchPlugin(rawCode)] : [unpkgPathPlugin(), fetchPlugin(rawCode)];
+                    _d.label = 3;
+                case 3:
+                    _d.trys.push([3, 5, , 6]);
+                    return [4 /*yield*/, service.build({
+                            entryPoints: [entryPoint],
+                            bundle: true,
+                            write: false,
+                            plugins: plugins,
+                            define: {
+                                'process.env.NODE_ENV': '"production"',
+                                global: 'window'
+                            },
+                        })];
+                case 4:
+                    result = _d.sent();
+                    return [2 /*return*/, {
+                            code: result.outputFiles[0].text,
+                            err: '',
+                        }];
+                case 5:
+                    err_1 = _d.sent();
+                    return [2 /*return*/, {
+                            code: '',
+                            err: err_1.message,
+                        }];
+                case 6: return [2 /*return*/];
+            }
+        });
     });
-}); };
+};
 export default bundle;

--- a/lib/esm/index.js
+++ b/lib/esm/index.js
@@ -65,7 +65,7 @@ var bundle = function (_a) {
                             write: false,
                             plugins: plugins,
                             define: {
-                                'process.env.NODE_ENV': '"production"',
+                                [['process','env','NODE_ENV'].join(".")]: '"production"',
                                 global: 'window'
                             },
                         })];

--- a/lib/esm/plugins/fetch-plugin.d.ts
+++ b/lib/esm/plugins/fetch-plugin.d.ts
@@ -3,3 +3,7 @@ export declare const fetchPlugin: (inputCode: string) => {
     name: string;
     setup(build: esbuild.PluginBuild): void;
 };
+export declare const tsxFetchPlugin: (inputCode: string) => {
+    name: string;
+    setup(build: esbuild.PluginBuild): void;
+};

--- a/lib/esm/plugins/fetch-plugin.js
+++ b/lib/esm/plugins/fetch-plugin.js
@@ -37,7 +37,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 import localForage from 'localforage';
 import axios from 'axios';
 var fileCache = localForage.createInstance({
-    name: 'filecache'
+    name: 'filecache',
 });
 export var fetchPlugin = function (inputCode) {
     return {
@@ -73,10 +73,7 @@ export var fetchPlugin = function (inputCode) {
                         case 0: return [4 /*yield*/, axios.get(args.path)];
                         case 1:
                             _a = _b.sent(), data = _a.data, request = _a.request;
-                            escaped = data
-                                .replace(/\n/g, '')
-                                .replace(/"/g, '\\"')
-                                .replace(/'/g, "\\'");
+                            escaped = data.replace(/\n/g, '').replace(/"/g, '\\"').replace(/'/g, "\\'");
                             contents = "\n            const style = document.createElement('style');\n            style.innerText = '" + escaped + "';\n            document.head.appendChild(style);\n          ";
                             result = {
                                 loader: 'jsx',
@@ -110,6 +107,78 @@ export var fetchPlugin = function (inputCode) {
                     }
                 });
             }); });
-        }
+        },
+    };
+};
+export var tsxFetchPlugin = function (inputCode) {
+    return {
+        name: 'fetch-plugin',
+        setup: function (build) {
+            var _this = this;
+            // load index.ts file
+            build.onLoad({ filter: /(^index\.ts$)/ }, function () {
+                return {
+                    loader: 'tsx',
+                    contents: inputCode,
+                };
+            });
+            // check the file cache
+            build.onLoad({ filter: /.*/ }, function (args) { return __awaiter(_this, void 0, void 0, function () {
+                var cachedResult;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0: return [4 /*yield*/, fileCache.getItem(args.path)];
+                        case 1:
+                            cachedResult = _a.sent();
+                            if (cachedResult) {
+                                return [2 /*return*/, cachedResult];
+                            }
+                            return [2 /*return*/];
+                    }
+                });
+            }); });
+            // load css files
+            build.onLoad({ filter: /.css$/ }, function (args) { return __awaiter(_this, void 0, void 0, function () {
+                var _a, data, request, escaped, contents, result;
+                return __generator(this, function (_b) {
+                    switch (_b.label) {
+                        case 0: return [4 /*yield*/, axios.get(args.path)];
+                        case 1:
+                            _a = _b.sent(), data = _a.data, request = _a.request;
+                            escaped = data.replace(/\n/g, '').replace(/"/g, '\\"').replace(/'/g, "\\'");
+                            contents = "\n            const style = document.createElement('style');\n            style.innerText = '" + escaped + "';\n            document.head.appendChild(style);\n          ";
+                            result = {
+                                loader: 'ts',
+                                contents: contents,
+                                resolveDir: new URL('./', request.responseURL).pathname,
+                            };
+                            return [4 /*yield*/, fileCache.setItem(args.path, result)];
+                        case 2:
+                            _b.sent();
+                            return [2 /*return*/, result];
+                    }
+                });
+            }); });
+            // load javascript / jsx files
+            build.onLoad({ filter: /.*/ }, function (args) { return __awaiter(_this, void 0, void 0, function () {
+                var _a, data, request, result;
+                return __generator(this, function (_b) {
+                    switch (_b.label) {
+                        case 0: return [4 /*yield*/, axios.get(args.path)];
+                        case 1:
+                            _a = _b.sent(), data = _a.data, request = _a.request;
+                            result = {
+                                loader: 'tsx',
+                                contents: data,
+                                resolveDir: new URL('./', request.responseURL).pathname,
+                            };
+                            return [4 /*yield*/, fileCache.setItem(args.path, result)];
+                        case 2:
+                            _b.sent();
+                            return [2 /*return*/, result];
+                    }
+                });
+            }); });
+        },
     };
 };

--- a/lib/esm/plugins/unpkg-path-plugin.d.ts
+++ b/lib/esm/plugins/unpkg-path-plugin.d.ts
@@ -3,3 +3,7 @@ export declare const unpkgPathPlugin: () => {
     name: string;
     setup(build: esbuild.PluginBuild): void;
 };
+export declare const tsUnpkgPathPlugin: () => {
+    name: string;
+    setup(build: esbuild.PluginBuild): void;
+};

--- a/lib/esm/plugins/unpkg-path-plugin.js
+++ b/lib/esm/plugins/unpkg-path-plugin.js
@@ -62,3 +62,31 @@ export var unpkgPathPlugin = function () {
         },
     };
 };
+export var tsUnpkgPathPlugin = function () {
+    return {
+        name: 'unpkg-path-plugin',
+        setup: function (build) {
+            var _this = this;
+            // handle root entry file of 'index.ts'
+            build.onResolve({ filter: /(^index\.ts$)/ }, function () {
+                return { path: 'index.ts', namespace: 'a' };
+            });
+            // handle relative paths in a module
+            build.onResolve({ filter: /^\.+\// }, function (args) {
+                return {
+                    namespace: 'a',
+                    path: new URL(args.path, 'https://unpkg.com' + args.resolveDir + '/').href,
+                };
+            });
+            // handle main file of a module
+            build.onResolve({ filter: /.*/ }, function (args) { return __awaiter(_this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
+                    return [2 /*return*/, {
+                            namespace: 'a',
+                            path: "https://unpkg.com/" + args.path,
+                        }];
+                });
+            }); });
+        },
+    };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,13 +9,14 @@ let service: esbuild.Service;
 interface BundleArgs {
   rawCode: string;
   typescript?: boolean;
+  versionTag?: string;
 }
 
-const bundle = async ({ rawCode, typescript = false }: BundleArgs) => {
+const bundle = async ({ rawCode, typescript = false, versionTag = '0.8.36' }: BundleArgs) => {
   if (!service) {
     service = await esbuild.startService({
       worker: true,
-      wasmURL: 'https://unpkg.com/esbuild-wasm@0.8.36/esbuild.wasm'
+      wasmURL: `https://unpkg.com/esbuild-wasm@${versionTag}/esbuild.wasm`,
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ const bundle = async ({ rawCode, typescript = false, versionTag = '0.8.36' }: Bu
       plugins,
       define: {
         // vite somehow overwrite the string 'process.env.NODE_ENV' with the actual process.env.NODE_ENV values, so we must trick it
-        'process'+'.env.NODE_ENV': '"production"',
+        [['process','env','NODE_ENV'].join(".")]: '"production"',
         global: 'window'
       },
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,8 @@ const bundle = async ({ rawCode, typescript = false, versionTag = '0.8.36' }: Bu
       write: false,
       plugins,
       define: {
-        'process.env.NODE_ENV': '"production"',
+        // vite somehow overwrite the string 'process.env.NODE_ENV' with the actual process.env.NODE_ENV values, so we must trick it
+        'process'+'.env.NODE_ENV': '"production"',
         global: 'window'
       },
     });


### PR DESCRIPTION
When using `unpkg-bundler` as of 22-08-28 yields the following error:

 > error: Cannot start service: Host version "0.8.57" does not match binary version "0.8.36

Looks like Unpkg is returning a few minor versions above requested, this commit ads a bundle argument to configure the esbuild.wasm version